### PR TITLE
task-8

### DIFF
--- a/rs-cart-api/.dockerignore
+++ b/rs-cart-api/.dockerignore
@@ -1,0 +1,19 @@
+# Versioning and metadata
+.git
+.gitignore
+.dockerignore
+
+# Build dependencies
+dist
+node_modules
+coverage
+
+# Environment (contains sensitive data)
+.env
+
+# Files not required for production
+.editorconfig
+Dockerfile
+README.md
+tslint.json
+nodemon.json

--- a/rs-cart-api/Dockerfile
+++ b/rs-cart-api/Dockerfile
@@ -1,6 +1,5 @@
 # Base
 FROM node:12-alpine AS base
-
 WORKDIR /app
 
 # Dependencies

--- a/rs-cart-api/README.md
+++ b/rs-cart-api/README.md
@@ -63,7 +63,7 @@ $ npm run test:cov
 ```bash
 # The -t option is for giving our image a name, i.e., tagging it.
 $ docker build -t my-cart-api-dev .
-# And then run it:
+# and then run it:
 $ docker run my-cart-api-dev
 
 $ docker images

--- a/rs-cart-api/README.md
+++ b/rs-cart-api/README.md
@@ -6,7 +6,7 @@
 [travis-url]: https://travis-ci.org/nestjs/nest
 [linux-image]: https://img.shields.io/travis/nestjs/nest/master.svg?label=linux
 [linux-url]: https://travis-ci.org/nestjs/nest
-  
+
   <p align="center">A progressive <a href="http://nodejs.org" target="blank">Node.js</a> framework for building efficient and scalable server-side applications, heavily inspired by <a href="https://angular.io" target="blank">Angular</a>.</p>
     <p align="center">
 <a href="https://www.npmjs.com/~nestjscore"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
@@ -58,6 +58,28 @@ $ npm run test:e2e
 
 # test coverage
 $ npm run test:cov
+```
+## Docker
+```bash
+# The -t option is for giving our image a name, i.e., tagging it.
+$ docker build -t my-cart-api-dev .
+# And then run it:
+$ docker run my-cart-api-dev
+
+$ docker images
+
+```
+
+## AWS Elastic Beanstalk
+```bash
+$ eb create my-cart-api-dev --elb-type application
+$ eb create development --single --cname my-cart-api-dev
+$ eb create development -s --envvars NODE_ENV=production, ENV_CONFIG=dev
+
+$ eb deploy my-cart-api-dev
+
+$ eb terminate my-cart-api-dev
+$ eb restore ${id}
 ```
 
 ## Support

--- a/rs-cart-api/package.json
+++ b/rs-cart-api/package.json
@@ -20,7 +20,8 @@
     "test:watch:file": "npm run test:watch -- app.controller",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "deploy:dev": "eb deploy my-cart-api-dev"
   },
   "dependencies": {
     "@nestjs/common": "^7.5.1",

--- a/rs-cart-api/src/main.ts
+++ b/rs-cart-api/src/main.ts
@@ -7,11 +7,11 @@ import { AppModule } from './app.module';
 const port = process.env.PORT || 4000;
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, { cors: true });
 
-  app.enableCors({
-    origin: (req, callback) => callback(null, true),
-  });
+  // app.enableCors({
+  //   origin: (req, callback) => callback(null, true),
+  // });
   app.use(helmet());
 
   await app.listen(port);


### PR DESCRIPTION
Task 8.1 - DONE
- .dockerignore created
- image size = 140MB 
![docker_image_size](https://user-images.githubusercontent.com/25580188/123972098-3bcbe380-d9c3-11eb-81f3-8d634412fc84.png)
- build time with changes in "package.json" = 83.3s
![docker_image_build_time_with_package_json](https://user-images.githubusercontent.com/25580188/123973079-1db2b300-d9c4-11eb-95a2-4b7f9c035cbd.PNG)
- build time without changes in "package.json" = 1.8s
![docker_image_build_time_without_package_json](https://user-images.githubusercontent.com/25580188/123973644-9c0f5500-d9c4-11eb-8a2f-204ce073a216.PNG)
s

Task 8.2 - DONE
- Cart API deployed using AWS EB CLI 
- FE PR: https://github.com/veldymanov/tile-shop-fe/pull/9
- WebSite: https://d2lvjuwl8mt9u1.cloudfront.net/

Testing
Unfortunately AWS Elastic Beanstalk is using http protocol by default. And this is the real problem to enable https, especially if load balancer is not used. So, to avoid browser mixed content blocking there are 2 ways to test:
- from https://d2lvjuwl8mt9u1.cloudfront.net/. But in this case you should enable mixed content in your browser: https://experienceleague.adobe.com/docs/target/using/experiences/vec/troubleshoot-composer/mixed-content.html?lang=en
- use simple GET requests: http://my-cart-api-dev.eu-west-1.elasticbeanstalk.com or http://my-cart-api-dev.eu-west-1.elasticbeanstalk.com/ping

PS: this MR does not reflect all the BE changes. See original files instead.